### PR TITLE
fix: only filter out events if filters selected

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -121,13 +121,13 @@ export default function EventList({
             return county.length === 0 || county.includes(event.county);
           })
           .filter((event) => {
-            if (!event.eventTypes) {
+            if (!event.eventTypes && type.length > 0) {
               return false;
             }
             return type.length === 0 || event.eventTypes.some((eventType) => type.includes(eventType));
           })
           .filter((event) => {
-            if (!event.eventFilters) {
+            if (!event.eventFilters && filter.length > 0) {
               return false;
             }
             return filter.length === 0 || event.eventFilters.some((eventFilter) => filter.includes(eventFilter));


### PR DESCRIPTION
A bug where a lot of events would not show up if no event filters were selected, and the events would not have a filter on it.